### PR TITLE
New helper nodeName to allow centralized formatting of hostnames

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -89,6 +89,17 @@ function has_location(d) {
          Math.abs(d.nodeinfo.location.longitude) < 180
 }
 
+function nodeName(d, trim) {
+  var name = ''
+  if (d && d.nodeinfo && d.nodeinfo.hostname)
+    name = d.nodeinfo.hostname
+  else if (d && d.nodeinfo && d.nodeinfo.node_id)
+    name = '[' + d.nodeinfo.node_id + ']'
+  if (trim && name.length > 48)
+    name = name.substring(0,48) + "..."
+  return name
+}
+
 function subtract(a, b) {
   var ids = {}
 

--- a/lib/infobox/link.js
+++ b/lib/infobox/link.js
@@ -4,13 +4,15 @@ define(function () {
     var a1 = document.createElement("a")
     a1.href = "#"
     a1.onclick = router.node(d.source.node)
-    a1.textContent = d.source.node.nodeinfo.hostname
+    a1.textContent = nodeName(d.source.node, true)
+    a1.title = nodeName(d.source.node)
     h2.appendChild(a1)
     h2.appendChild(document.createTextNode(" – "))
     var a2 = document.createElement("a")
     a2.href = "#"
     a2.onclick = router.node(d.target.node)
-    a2.textContent = d.target.node.nodeinfo.hostname
+    a2.textContent = nodeName(d.target.node, true)
+    a2.title = nodeName(d.target.node)
     h2.appendChild(a2)
     el.appendChild(h2)
 

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -175,7 +175,8 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
 
   return function(config, el, router, d) {
     var h2 = document.createElement("h2")
-    h2.textContent = d.nodeinfo.hostname
+    h2.textContent = nodeName(d, true)
+    h2.title = nodeName(d)
     el.appendChild(h2)
 
     var attributes = document.createElement("table")
@@ -242,7 +243,8 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
         var td1 = document.createElement("td")
         var a1 = document.createElement("a")
         a1.classList.add("hostname")
-        a1.textContent = d.node.nodeinfo.hostname
+        a1.textContent = nodeName(d.node, true)
+        a1.title = nodeName(d.node)
         a1.href = "#"
         a1.onclick = router.node(d.node)
         td1.appendChild(a1)

--- a/lib/linklist.js
+++ b/lib/linklist.js
@@ -1,6 +1,6 @@
 define(["sorttable", "virtual-dom"], function (SortTable, V) {
-  function linkName(d) {
-    return d.source.node.nodeinfo.hostname + " – " + d.target.node.nodeinfo.hostname
+  function linkName(d, trim) {
+    return nodeName(d.source.node, trim) + " – " + nodeName(d.target.node, trim)
   }
 
   var headings = [{ name: "Knoten",
@@ -25,7 +25,7 @@ define(["sorttable", "virtual-dom"], function (SortTable, V) {
     var table = new SortTable(headings, 2, renderRow)
 
     function renderRow(d) {
-      var td1Content = [V.h("a", {href: "#", onclick: router.link(d)}, linkName(d))]
+      var td1Content = [V.h("a", {href: "#", onclick: router.link(d), title: linkName(d)}, linkName(d, true))]
 
       if (d.vpn)
         td1Content.push(" (VPN)")

--- a/lib/map.js
+++ b/lib/map.js
@@ -77,7 +77,7 @@ define(["map/clientlayer", "map/labelslayer",
         }
 
         m.on("click", router.node(d))
-        m.bindLabel(d.nodeinfo.hostname)
+        m.bindLabel(nodeName(d))
 
         dict[d.nodeinfo.node_id] = m
 
@@ -103,7 +103,7 @@ define(["map/clientlayer", "map/labelslayer",
           line.setStyle(opts)
         }
 
-        line.bindLabel(d.source.node.nodeinfo.hostname + " – " + d.target.node.nodeinfo.hostname + "<br><strong>" + showDistance(d) + " / " + showTq(d) + "</strong>")
+        line.bindLabel(nodeName(d.source.node) + " – " + nodeName(d.target.node) + "<br><strong>" + showDistance(d) + " / " + showTq(d) + "</strong>")
         line.on("click", router.link(d))
 
         dict[d.id] = line

--- a/lib/map/labelslayer.js
+++ b/lib/map/labelslayer.js
@@ -31,14 +31,14 @@ define(["leaflet", "rbush"],
       return function (d) {
         var font = fontSize + "px " + fontFamily
         return { position: L.latLng(d.nodeinfo.location.latitude, d.nodeinfo.location.longitude),
-                 label: d.nodeinfo.hostname,
+                 label: nodeName(d),
                  offset: offset,
                  fillStyle: fillStyle,
                  height: fontSize * 1.2,
                  font: font,
                  stroke: stroke,
                  minZoom: minZoom,
-                 width: measureText(font, d.nodeinfo.hostname).width
+                 width: measureText(font, nodeName(d)).width
                }
       }
     }

--- a/lib/nodelist.js
+++ b/lib/nodelist.js
@@ -21,7 +21,7 @@ define(["sorttable", "virtual-dom", "numeral"], function (SortTable, V, numeral)
 
   var headings = [{ name: "Knoten",
                     sort: function (a, b) {
-                      return a.nodeinfo.hostname.localeCompare(b.nodeinfo.hostname)
+                      return nodeName(a).localeCompare(nodeName(b))
                     },
                     reverse: false
                   },
@@ -46,8 +46,9 @@ define(["sorttable", "virtual-dom", "numeral"], function (SortTable, V, numeral)
 
       td1Content.push(V.h("a", { className: aClass.join(" "),
                                  onclick: router.node(d),
-                                 href: "#"
-                               }, d.nodeinfo.hostname))
+                                 href: "#",
+                                 title: nodeName(d)
+                               }, nodeName(d, true)))
 
       if (has_location(d))
         td1Content.push(V.h("span", {className: "icon ion-location"}))

--- a/lib/simplenodelist.js
+++ b/lib/simplenodelist.js
@@ -41,8 +41,9 @@ define(["moment", "virtual-dom"], function (moment, V) {
 
         td1Content.push(V.h("a", { className: aClass.join(" "),
                                    onclick: router.node(d),
-                                   href: "#"
-                                 }, d.nodeinfo.hostname))
+                                   href: "#",
+                                   title: nodeName(d)
+                                 }, nodeName(d, true)))
 
         if (has_location(d))
           td1Content.push(V.h("span", {className: "icon ion-location"}))

--- a/lib/title.js
+++ b/lib/title.js
@@ -15,12 +15,12 @@ define(function () {
 
     this.gotoNode = function (d) {
       if (d)
-        setTitle(d.nodeinfo.hostname)
+        setTitle(nodeName(d))
     }
 
     this.gotoLink = function (d) {
       if (d)
-        setTitle(d.source.node.nodeinfo.hostname + " – " + d.target.node.nodeinfo.hostname)
+        setTitle(nodeName(d.source.node) + " – " + nodeName(d.target.node))
     }
 
     this.destroy = function () {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
       "offline": false,
       "one": false,
       "online": false,
+      "nodeName": false,
       "showDistance": false,
       "showTq": false,
       "sortByKey": false,


### PR DESCRIPTION
This PR adds a new helper "nodeName" to allow a centralized handling of extra long or empty hostnames.
Long node names will be trimmed to avoid layout issues, empty node names will be replaced with the node id in square brackets.
