### PR TITLE
Header in all-nodes view shorter on small screens

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,21 @@
+{
+  "dataPath": "https://map.luebeck.freifunk.net/data/",
+  "siteName": "Freifunk Lübeck",
+  "mapSigmaScale": 0.5,
+  "showContact": true,
+  "maxAge": 14,
+  "mapLayers": [
+    { "name": "MapQuest",
+      "url": "https://otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
+      "config": {
+        "subdomains": "1234",
+        "type": "osm",
+        "attribution": "Tiles &copy; <a href=\"https://www.mapquest.com/\" target=\"_blank\">MapQuest</a>, Data CC-BY-SA OpenStreetMap",
+        "maxZoom": 18
+      }
+    },
+    {
+      "name": "Stamen.TonerLite"
+    }
+  ]
+}

--- a/lib/nodelist.js
+++ b/lib/nodelist.js
@@ -64,6 +64,7 @@ define(["sorttable", "virtual-dom", "numeral"], function (SortTable, V, numeral)
     this.render = function (d) {
       var el = document.createElement("div")
       d.appendChild(el)
+      el.classList.add("all-nodes")
 
       var h2 = document.createElement("h2")
       h2.textContent = "Alle Knoten"

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -365,6 +365,34 @@ table {
       border-radius: 0;
     }
   }
+  
+}
+
+@media screen and (max-width: 320px) {
+  .all-nodes table th{
+    font-size:0pt;
+  }
+
+  .all-nodes table th:first-child:before,
+  .all-nodes table th:nth-of-type(2):before, 
+  .all-nodes table th:nth-of-type(3):before,
+  .all-nodes table th:after{
+    font-size:10pt;
+  }
+
+  .all-nodes table th:first-child{
+    font-size:10pt;
+  }
+
+  .all-nodes table th:nth-of-type(2):before{
+    content:"U";
+  }
+
+  .all-nodes table th:nth-of-type(3):before{
+    content:"C";
+  }
+
+
 }
 
 @media screen and (max-width: $minscreenwidth) {


### PR DESCRIPTION
This will change the label on top of the list for all nodes to just the first Letter "U" for "Uptime" and "C" for "Clients"
