### PR TITLE
Header in all-nodes view rotaded 90° on small screens

### DIFF
--- a/lib/nodelist.js
+++ b/lib/nodelist.js
@@ -64,6 +64,7 @@ define(["sorttable", "virtual-dom", "numeral"], function (SortTable, V, numeral)
     this.render = function (d) {
       var el = document.createElement("div")
       d.appendChild(el)
+      el.classList.add("all-nodes")
 
       var h2 = document.createElement("h2")
       h2.textContent = "Alle Knoten"

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -365,6 +365,23 @@ table {
       border-radius: 0;
     }
   }
+  
+}
+
+@media screen and (max-width: 320px) {
+  .all-nodes th:not(:first-child){
+    font-size:8pt;
+    -webkit-transform: rotate(90deg);
+    -moz-transform: rotate(90deg);
+    -o-transform: rotate(90deg);
+    -ms-transform: rotate(90deg);
+    transform: rotate(90deg);
+    max-width: 15pt;
+    padding-bottom: 24pt;
+  }
+  .tabs li{
+    font-size: 0.8em;
+  }
 }
 
 @media screen and (max-width: $minscreenwidth) {


### PR DESCRIPTION
This will rotate the labels in the table 90° so the meshviewer is usable on small devices ( < 320px width)
